### PR TITLE
Fix building on MinGW

### DIFF
--- a/Hurrican/CMakeLists.txt
+++ b/Hurrican/CMakeLists.txt
@@ -440,8 +440,8 @@ include_directories(${SDL_INCLUDE_DIR})
 include_directories(${LibEpoxy_INCLUDE_DIRS})
 
 target_link_libraries(${PROJECT_NAME} ${SDL_LIBRARY} ${SDL_MIXER_LIBRARIES} ${SDL_IMAGE_LIBRARIES} ${OPENGL_LIBRARIES} ${LibEpoxy_LIBRARIES} modplug)
-if(UNIX)
-    target_link_libraries(${PROJECT_NAME} stdc++fs)
+if(UNIX OR MINGW)
+   target_link_libraries(${PROJECT_NAME} stdc++fs)
 endif()
 
 if(UNIX)

--- a/Hurrican/src/SDLPort/SDL_port.cpp
+++ b/Hurrican/src/SDLPort/SDL_port.cpp
@@ -32,7 +32,7 @@ GLenum MatrixMode = 0;
 #endif
 glm::mat4x4 g_matView;
 glm::mat4x4 g_matModelView;
-#ifndef __WIN32__
+#if !defined( __WIN32__) || defined(__MINGW32__)
 void strcat_s(char *dst, const char *src) {
     strcat(dst, src);
 }

--- a/Hurrican/src/SDLPort/SDL_port.hpp
+++ b/Hurrican/src/SDLPort/SDL_port.hpp
@@ -86,7 +86,7 @@ struct D3DXVECTOR2 {
     float y;
 };
 
-#ifndef __WIN32__
+#if !defined( __WIN32__) || defined(__MINGW32__)
 void strcat_s(char *dst, const char *src);
 void strcat_s(char *dst, uint32_t size, const char *src);
 void strncat_s(char *dst, const char *src, uint32_t size);


### PR DESCRIPTION
A couple of fixes to allow building on MinGW:
* std::experimental::filesystem is used unconditionally so stdc++fs need to be linked;
* system strncat_s has a different signature so use the internal one.