### PR TITLE
Correct shaders header

### DIFF
--- a/Hurrican/src/DX8Graphics.cpp
+++ b/Hurrican/src/DX8Graphics.cpp
@@ -281,7 +281,8 @@ bool DirectGraphicsClass::Init(std::uint32_t dwBreite, std::uint32_t dwHoehe, st
     VSyncEnabled = VSync;
 #endif  // END VSYNC-RELATED CODE
 
-    SetDeviceInfo();
+    if (!SetDeviceInfo())
+        return false;
 
     Protokoll << "\n-> OpenGL init successful!\n" << std::endl;
 

--- a/Hurrican/src/SDLPort/cshader.cpp
+++ b/Hurrican/src/SDLPort/cshader.cpp
@@ -105,8 +105,14 @@ GLuint CShader::CompileShader(GLenum type, const std::string &path) {
     source.insert(source.begin(), version.begin(), version.end());
 #elif defined(USE_GLES3)
     const std::string version = "#version 320 es\n";
-    const std::string precision = "precision highp float;\n";
+    const std::string precision = "#ifdef GL_FRAGMENT_PRECISION_HIGH\nprecision highp float;\n#else\nprecision mediump float;\n#endif\n";
     source.insert(source.begin(), precision.begin(), precision.end());
+    source.insert(source.begin(), version.begin(), version.end());
+#elif defined(USE_GL2)
+    const std::string version = "#version 110\n";
+    source.insert(source.begin(), version.begin(), version.end());
+#elif defined(USE_GL3)
+    const std::string version = "#version 130\n";
     source.insert(source.begin(), version.begin(), version.end());
 #endif
 


### PR DESCRIPTION
- insert shader version for non ES cases too;
- added check for precision highp support which is not mandatory in GL ES 3 standard;
- exit if there's an error loading shaders.